### PR TITLE
OCR-128 Build for macOS 10.7

### DIFF
--- a/dlproject.yaml
+++ b/dlproject.yaml
@@ -74,6 +74,7 @@ config:
     #     Lists are appended
 
     macos:
+        profile: apple-clang-9.1-macos-10.7
 
     redhat:
         # Use the RedHat Devtoolset 7 on Linux
@@ -93,6 +94,7 @@ config:
             - boost_build
 
     windows:
+        profile: profile: visual-studio-14
         cmake_generator: Visual Studio 12 2013 Win64
         multi: true
 


### PR DESCRIPTION
**Please do [datalogics/conan-config#5](https://octocat.dlogics.com/datalogics/conan-config/pull/5) first**

## Fulfills [OCR-128](https://jira.datalogics.com/browse/OCR-128)

Build for a macOS deployment target of 10.7

- Using the profile for apple-clang-9.1-macos-10.7

- While at it, set the profile for visual-studio-14